### PR TITLE
Update alpine and webproc, create automated build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: Build Docker Image
+on:
+  push:
+    branches: master
+
+jobs:
+  build:
+    name: Push to GHCR
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Login
+      run: echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u dchidell --password-stdin
+    - name: Build
+      run: docker build . --file Dockerfile --tag ghcr.io/dchidell/dnsmasq-web:latest
+    - name: Push
+      run: |
+        docker push ghcr.io/dchidell/dnsmasq-web:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM alpine:3.11 as build
+FROM alpine:3.14 as build
 LABEL maintainer="David Chidell (dchidell@cisco.com)"
 
 FROM build as webproc
-ENV WEBPROC_VERSION 0.2.2
-ENV WEBPROC_URL https://github.com/jpillora/webproc/releases/download/$WEBPROC_VERSION/webproc_linux_amd64.gz
+ENV WEBPROCVERSION 0.4.0
+ENV WEBPROCURL https://github.com/jpillora/webproc/releases/download/v$WEBPROCVERSION/webproc_"$WEBPROCVERSION"_linux_amd64.gz
 RUN apk add --no-cache curl
-RUN curl -sL $WEBPROC_URL | gzip -d - > /usr/local/bin/webproc
+RUN curl -sL $WEBPROCURL | gzip -d - > /usr/local/bin/webproc
 RUN chmod +x /usr/local/bin/webproc
 
 FROM build as dnsmasq
 RUN apk --no-cache add dnsmasq
 COPY --from=webproc /usr/local/bin/webproc /usr/local/bin/webproc
-ENTRYPOINT ["webproc","--on-exit","restart","--config","/etc/dnsmasq.conf,/etc/hosts,/etc/resolv.conf","--","dnsmasq","-k","--log-facility=-"]
+ENTRYPOINT ["webproc","-o","restart","-c","/etc/dnsmasq.conf","-c","/etc/hosts","-c","/etc/resolv.conf","--","dnsmasq","-k","--log-facility=-"]
 EXPOSE 53/udp 8080


### PR DESCRIPTION
In this commit I've done the following. These changes have been tested and confirmed to work.

- Updated Alpine to 3.14 and Webproc to 0.4.0
- The WEBPROC variable names have changed due to a renaming of the downloadable assets on GitHub
- The Webproc flags have changed slightly due to an upstream syntax change